### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -61,7 +61,7 @@ class ClassMapGenerator
      *
      * @return $this
      */
-    public function avoidDuplicateScans(FileList $scannedFiles = null): self
+    public function avoidDuplicateScans(?FileList $scannedFiles = null): self
     {
         $this->scannedFiles = $scannedFiles ?? new FileList;
 
@@ -100,7 +100,7 @@ class ClassMapGenerator
      *
      * @throws \RuntimeException When the path is neither an existing file nor directory
      */
-    public function scanPaths($path, string $excluded = null, string $autoloadType = 'classmap', ?string $namespace = null): void
+    public function scanPaths($path, ?string $excluded = null, string $autoloadType = 'classmap', ?string $namespace = null): void
     {
         if (!in_array($autoloadType, ['psr-0', 'psr-4', 'classmap'], true)) {
             throw new \InvalidArgumentException('$autoloadType must be one of: "psr-0", "psr-4" or "classmap"');

--- a/src/PhpFileCleaner.php
+++ b/src/PhpFileCleaner.php
@@ -240,7 +240,7 @@ class PhpFileCleaner
      * @param non-empty-string $regex
      * @param null|array<int, string> $match
      */
-    private function match(string $regex, array &$match = null): bool
+    private function match(string $regex, ?array &$match = null): bool
     {
         return Preg::isMatch($regex, $this->contents, $match, 0, $this->index);
     }


### PR DESCRIPTION
Fixes all issues that emits a deprecation notice on PHP 8.4.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)