### PR TITLE
feat: ClassMapGenerator::scanPaths can exclude specific dirs

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -97,10 +97,11 @@ class ClassMapGenerator
      * @param non-empty-string|null                                 $excluded     Regex that matches file paths to be excluded from the classmap
      * @param 'classmap'|'psr-0'|'psr-4'                            $autoloadType Optional autoload standard to use mapping rules with the namespace instead of purely doing a classmap
      * @param string|null                                           $namespace    Optional namespace prefix to filter by, only for psr-0/psr-4 autoloading
+     * @param string|array<string>                                  $excludedDirs Optional dirs to exclude from search relative to $path
      *
      * @throws \RuntimeException When the path is neither an existing file nor directory
      */
-    public function scanPaths($path, ?string $excluded = null, string $autoloadType = 'classmap', ?string $namespace = null): void
+    public function scanPaths($path, ?string $excluded = null, string $autoloadType = 'classmap', ?string $namespace = null, $excludedDirs = []): void
     {
         if (!in_array($autoloadType, ['psr-0', 'psr-4', 'classmap'], true)) {
             throw new \InvalidArgumentException('$autoloadType must be one of: "psr-0", "psr-4" or "classmap"');
@@ -124,7 +125,8 @@ class ClassMapGenerator
                     ->files()
                     ->followLinks()
                     ->name('/\.(?:'.implode('|', array_map('preg_quote', $this->extensions)).')$/')
-                    ->in($path);
+                    ->in($path)
+                    ->exclude($excludedDirs);
             } else {
                 throw new \RuntimeException(
                     'Could not scan for classes inside "'.$path.'" which does not appear to be a file nor a folder'

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -240,6 +240,18 @@ class ClassMapGeneratorTest extends TestCase
         self::assertEqualsNormalized($expected, $result);
     }
 
+    public function testCreateMapWithDirectoryExcluded(): void
+    {
+        $expected = array(
+            'PrefixCollision_A_B_Bar' => realpath(__DIR__) . '/Fixtures/beta/PrefixCollision/A/B/Bar.php',
+            'PrefixCollision_A_B_Foo' => realpath(__DIR__) . '/Fixtures/beta/PrefixCollision/A/B/Foo.php',
+        );
+
+        $this->generator->scanPaths(realpath(__DIR__) . '/Fixtures/beta', null, 'classmap', null, 'NamespaceCollision');
+        $result = $this->generator->getClassMap();
+        self::assertEqualsNormalized($expected, $result->getMap());
+    }
+
     /**
      * @param array<string, string> $expected
      * @param array<class-string, string> $actual


### PR DESCRIPTION
Closes #6 

Class Finder from Symfony is used to get an iterator on files matching the first argument of scanPaths. Currently if we want to exclude some files from the search we can provide a regex which will be test on each file.

Finder has a method exclude() which allow us to exclude a list of dirs relative to the one passed in in(). It does a pre-filtering much more efficient than checking the regex.

To keep backward compatibility, this new argument is added at then end of the method with a default value.