### PR TITLE
Detect other PSR violations where namespace is missing or not a subnamespace of configured one

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -216,10 +216,6 @@ class ClassMapGenerator
         $realSubPath = substr($realSubPath, 0, $dotPosition === false ? PHP_INT_MAX : $dotPosition);
 
         foreach ($classes as $class) {
-            // silently skip if ns doesn't have common root
-            if ('' !== $baseNamespace && 0 !== strpos($class, $baseNamespace)) {
-                continue;
-            }
             // transform class name to file path and validate
             if ('psr-0' === $namespaceType) {
                 $namespaceLength = strrpos($class, '\\');

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -247,8 +247,8 @@ class ClassMapGeneratorTest extends TestCase
         self::assertSame(
             [
                 'Class ClassWithoutNameSpace located in ./tests/Fixtures/psrViolations/ClassWithoutNameSpace.php does not comply with psr-4 autoloading standard. Skipping.',
-                'Class ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace located in ./tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php does not comply with psr-4 autoloading standard. Skipping.',
                 'Class UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope located in ./tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php does not comply with psr-4 autoloading standard. Skipping.',
+                'Class ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace located in ./tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php does not comply with psr-4 autoloading standard. Skipping.',
             ],
             $classMap->getPsrViolations()
         );

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -240,6 +240,18 @@ class ClassMapGeneratorTest extends TestCase
         self::assertEqualsNormalized($expected, $result);
     }
 
+    public function testGetPSR4Violations(): void
+    {
+        $this->generator->scanPaths(__DIR__ . '/Fixtures/psrViolations', null, 'psr-4', 'ExpectedNamespace\\');
+        $classMap = $this->generator->getClassMap();
+        static::assertSame(
+            [
+                'Class ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace located in ./tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php does not comply with psr-4 autoloading standard. Skipping.',
+            ],
+            $classMap->getPsrViolations()
+        );
+    }
+
     /**
      * @param array<string, string> $expected
      * @param array<class-string, string> $actual

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -246,7 +246,9 @@ class ClassMapGeneratorTest extends TestCase
         $classMap = $this->generator->getClassMap();
         static::assertSame(
             [
+                'Class ClassWithoutNameSpace located in ./tests/Fixtures/psrViolations/ClassWithoutNameSpace.php does not comply with psr-4 autoloading standard. Skipping.',
                 'Class ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace located in ./tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php does not comply with psr-4 autoloading standard. Skipping.',
+                'Class UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope located in ./tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php does not comply with psr-4 autoloading standard. Skipping.',
             ],
             $classMap->getPsrViolations()
         );

--- a/tests/Fixtures/psrViolations/ClassWithCorrectNameSpace.php
+++ b/tests/Fixtures/psrViolations/ClassWithCorrectNameSpace.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace ExpectedNamespace;
+
+class ClassWithCorrectNameSpace {}

--- a/tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php
+++ b/tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace ExpectedNamespace\UnexpectedSubNamespace;
+
+class ClassWithIncorrectSubNamespace {}

--- a/tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php
+++ b/tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace UnexpectedNamespace;
+
+class ClassWithNameSpaceOutsideConfiguredScope {}

--- a/tests/Fixtures/psrViolations/ClassWithoutNameSpace.php
+++ b/tests/Fixtures/psrViolations/ClassWithoutNameSpace.php
@@ -1,0 +1,3 @@
+<?php
+
+class ClassWithoutNameSpace {}


### PR DESCRIPTION
Fixes https://github.com/composer/composer/issues/11957

To get warnings about missing namespaces or non-common namespaces in Composer when running with --strict-psr, classes shouldn't be skipped before checking their namespace if they don't have a common root. 