### PR TITLE
Add throws docblock to `ClassMapGenerator@filterByNamespace()`

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -207,6 +207,8 @@ class ClassMapGenerator
      * @param  'psr-0'|'psr-4'          $namespaceType
      * @param  string                   $basePath      root directory of given autoload mapping
      * @return array<int, class-string> valid classes
+     *
+     * @throws \InvalidArgumentException When namespaceType is neither psr-0 nor psr-4
      */
     private function filterByNamespace(array $classes, string $filePath, string $baseNamespace, string $namespaceType, string $basePath): array
     {


### PR DESCRIPTION
As the title suggests, adds a throws docblock where one did not previously exist.