### PR TITLE
Add `ClassMap@getRawPsrViolations()`

### DIFF
--- a/src/ClassMap.php
+++ b/src/ClassMap.php
@@ -176,4 +176,16 @@ class ClassMap implements \Countable
     {
         return \count($this->map);
     }
+
+    /**
+     * Get the raw psr violations
+     *
+     * This is a map of filepath to an associative array of the warning string
+     * and the offending class name.
+     * @return array<string, array<array{warning: string, className: string}>>
+     */
+    public function getRawPsrViolations(): array
+    {
+        return $this->psrViolations;
+    }
 }

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -277,6 +277,32 @@ class ClassMapGeneratorTest extends TestCase
         );
     }
 
+    public function testGetRawPSR4Violations(): void
+    {
+        $this->generator->scanPaths(__DIR__ . '/Fixtures/psrViolations', null, 'psr-4', 'ExpectedNamespace\\');
+        $classMap = $this->generator->getClassMap();
+        $rawViolations = $classMap->getRawPsrViolations();
+
+        $classWithoutNameSpaceFilepath = __DIR__ . '/Fixtures/psrViolations/ClassWithoutNameSpace.php';
+        $classWithIncorrectSubNamespaceFilepath = __DIR__ . '/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php';
+        $classWithNameSpaceOutsideConfiguredScopeFilepath = __DIR__ . '/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php';
+
+        self::assertArrayHasKey($classWithoutNameSpaceFilepath, $rawViolations);
+        self::assertCount(1, $rawViolations[$classWithoutNameSpaceFilepath]);
+        self::assertSame('Class ClassWithoutNameSpace located in ./tests/Fixtures/psrViolations/ClassWithoutNameSpace.php does not comply with psr-4 autoloading standard (rule: ExpectedNamespace\ => ./tests/Fixtures/psrViolations). Skipping.', $rawViolations[$classWithoutNameSpaceFilepath][0]['warning']);
+        self::assertSame('ClassWithoutNameSpace', $rawViolations[$classWithoutNameSpaceFilepath][0]['className']);
+
+        self::assertArrayHasKey($classWithIncorrectSubNamespaceFilepath, $rawViolations);
+        self::assertCount(1, $rawViolations[$classWithIncorrectSubNamespaceFilepath]);
+        self::assertSame('Class ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace located in ./tests/Fixtures/psrViolations/ClassWithIncorrectSubNamespace.php does not comply with psr-4 autoloading standard (rule: ExpectedNamespace\ => ./tests/Fixtures/psrViolations). Skipping.', $rawViolations[$classWithIncorrectSubNamespaceFilepath][0]['warning']);
+        self::assertSame('ExpectedNamespace\UnexpectedSubNamespace\ClassWithIncorrectSubNamespace', $rawViolations[$classWithIncorrectSubNamespaceFilepath][0]['className']);
+
+        self::assertArrayHasKey($classWithNameSpaceOutsideConfiguredScopeFilepath, $rawViolations);
+        self::assertCount(1, $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath]);
+        self::assertSame('Class UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope located in ./tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php does not comply with psr-4 autoloading standard (rule: ExpectedNamespace\ => ./tests/Fixtures/psrViolations). Skipping.', $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath][0]['warning']);
+        self::assertSame('UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope', $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath][0]['className']);
+    }
+
     public function testCreateMapWithDirectoryExcluded(): void
     {
         $expected = array(


### PR DESCRIPTION
## Motivation
I'd like to build a step in our gitlab pipeline that confirms that all files meet the PSR-4 namespace standard.

## How it can be solved now
* Use reflection to extract the `$psrViolations` from `ClassMap`, or
* Attempt to parse the strings from the warnings returned from `ClassMap@getPsrViolations()`

## Changes
Adds a method to get the raw violations (`ClassMap@getRawPsrViolations()`) and add tests.