### PR TITLE
Always treat stream wrappers as absolute paths

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -45,10 +45,10 @@ class ClassMapGenerator
      */
     private $classMap;
 
-    /*
-     * @var string
+    /**
+     * @var non-empty-string
      */
-    private $streamWrappers;
+    private $streamWrappersRegex;
 
     /**
      * @param list<string> $extensions File extensions to scan for classes in the given paths
@@ -57,7 +57,7 @@ class ClassMapGenerator
     {
         $this->extensions = $extensions;
         $this->classMap = new ClassMap;
-        $this->streamWrappers = implode('|', stream_get_wrappers());
+        $this->streamWrappersRegex = sprintf('{^(%s)://}', implode('|', stream_get_wrappers()));
     }
 
     /**
@@ -148,7 +148,7 @@ class ClassMapGenerator
                 continue;
             }
 
-            if (!self::isAbsolutePath($filePath) && !Preg::isMatch('{^('.$this->streamWrappers.')://}', $filePath)) {
+            if (!self::isAbsolutePath($filePath) && !Preg::isMatch($this->streamWrappersRegex, $filePath)) {
                 $filePath = $cwd . '/' . $filePath;
                 $filePath = self::normalizePath($filePath);
             } else {
@@ -159,9 +159,9 @@ class ClassMapGenerator
                 throw new \LogicException('Got an empty $filePath for '.$file->getPathname());
             }
 
-            $realPath = !Preg::isMatch('{^('.$this->streamWrappers.')://}', $filePath)
-	            ? realpath($filePath)
-	            : $filePath;
+            $realPath = !Preg::isMatch($this->streamWrappersRegex, $filePath)
+                ? realpath($filePath)
+                : $filePath;
 
             // fallback just in case but this really should not happen
             if (false === $realPath) {

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -182,13 +182,13 @@ class ClassMapGeneratorTest extends TestCase
              *
              * @return bool
              */
-            public function stream_open( $path, $mode, $options, &$opened_path ) {
-                $scheme  = parse_url( $path, PHP_URL_SCHEME );
-                $varname = str_replace( $scheme . '://', '', $path );
+            public function stream_open($path, $mode, $options, &$opened_path) {
+                $scheme  = parse_url($path, PHP_URL_SCHEME);
+                $varname = str_replace($scheme . '://', '', $path);
 
                 $this->real = 'file://' . self::$rootPath . '/' . $varname;
 
-                $this->resource = fopen( $this->real, $mode );
+                $this->resource = fopen($this->real, $mode);
 
                 return (bool) $this->resource;
             }
@@ -198,26 +198,24 @@ class ClassMapGeneratorTest extends TestCase
              *
              * @return false|string
              */
-            public function stream_read( $count ) {
-                return $this->resource === false ? false :
-                    fgets( $this->resource, $count );
+            public function stream_read($count) {
+                return $this->resource === false ? false : fgets($this->resource, (int) $count);
             }
 
             /**
              * @return array<int|string, int>|false
              */
             public function stream_stat() {
-                return $this->resource === false ? false :
-                    fstat( $this->resource );
+                return $this->resource === false ? false : fstat($this->resource);
             }
         };
 
-        $testProxyStreamWrapper::$rootPath = realpath( __DIR__ ) . '/Fixtures/classmap';
-        stream_wrapper_register( 'test', get_class( $testProxyStreamWrapper ) );
+        $testProxyStreamWrapper::$rootPath = realpath(__DIR__) . '/Fixtures/classmap';
+        stream_wrapper_register('test', get_class($testProxyStreamWrapper));
 
         $arrayOfSplFileInfoStreamPaths = [
-            new \SplFileInfo( 'test://BackslashLineEndingString.php' ),
-            new \SplFileInfo( 'test://InvalidUnicode.php' ),
+            new \SplFileInfo('test://BackslashLineEndingString.php'),
+            new \SplFileInfo('test://InvalidUnicode.php'),
         ];
 
         self::assertSame(
@@ -227,7 +225,7 @@ class ClassMapGeneratorTest extends TestCase
                 'Smarty_Internal_Compile_Block'      => 'test://InvalidUnicode.php',
                 'Smarty_Internal_Compile_Blockclose' => 'test://InvalidUnicode.php',
             ],
-            ClassMapGenerator::createMap( $arrayOfSplFileInfoStreamPaths )
+            ClassMapGenerator::createMap($arrayOfSplFileInfoStreamPaths)
         );
     }
 

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -18,7 +18,6 @@
 
 namespace Composer\ClassMapGenerator;
 
-use Composer\ClassMapGenerator\ClassMapGenerator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
@@ -149,6 +148,100 @@ class ClassMapGeneratorTest extends TestCase
             'NamespaceCollision\\A\\B\\Foo' => realpath(__DIR__) . '/Fixtures/beta/NamespaceCollision/A/B/Foo.php',
         ), ClassMapGenerator::createMap($finder));
     }
+
+	/**
+	 * @see ClassMapGenerator::isStreamWrapper()
+	 */
+	public function testStreamWrapperSupport(): void {
+
+		/**
+		 * A stream wrapper that given `test://myfile.php` will read `test://path/to/myfile.php` where `path/to` is
+		 * set on the `$rootPath` static variable.
+		 */
+		$testProxyStreamWrapper = new class() {
+			/**
+			 * @var string
+			 */
+			public static $rootPath;
+
+			/**
+			 * @var string
+			 */
+			protected $real;
+
+			/**
+			 * @var resource|false
+			 */
+			protected $resource;
+
+			/**
+			 * @param string $path
+			 * @param string $mode
+			 * @param int $options
+			 * @param ?string $opened_path
+			 *
+			 * @return bool
+			 */
+			public function stream_open($path, $mode, $options, &$opened_path)
+			{
+				$scheme = parse_url($path, PHP_URL_SCHEME);
+				$varname = str_replace( $scheme . '://', '', $path );
+
+				$this->real = 'file://' . self::$rootPath . '/' . $varname;
+
+				$this->resource = fopen($this->real, $mode);
+
+				return (bool) $this->resource;
+			}
+
+			/**
+			 * @param int<0, max>|null $count
+			 *
+			 * @return false|string
+			 */
+			public function stream_read($count)
+			{
+				return $this->resource === false ? false :
+					fgets($this->resource, $count);
+			}
+
+			/**
+			 * @return array|false
+			 */
+			public function stream_stat() {
+				return $this->resource === false ? false :
+					fstat($this->resource);
+			}
+
+			/**
+			 * @param string $path
+			 * @param int $flags
+			 *
+			 * @return array|false
+			 */
+			public function url_stat($path, $flags) {
+				return stat($this->real);
+			}
+		};
+
+		$testProxyStreamWrapper::$rootPath = realpath(__DIR__) . '/Fixtures/classmap';
+		stream_wrapper_register( 'test', get_class( $testProxyStreamWrapper ) );
+
+		$arrayOfSplFileInfoStreamPaths = [
+			new \SplFileInfo( 'test://BackslashLineEndingString.php'),
+			new \SplFileInfo( 'test://InvalidUnicode.php'),
+		];
+
+		self::assertSame(
+			[
+				'Foo\\SlashedA' => 'test://BackslashLineEndingString.php',
+				'Foo\\SlashedB' => 'test://BackslashLineEndingString.php',
+				'Smarty_Internal_Compile_Block' => 'test://InvalidUnicode.php',
+				'Smarty_Internal_Compile_Blockclose' => 'test://InvalidUnicode.php',
+			],
+			ClassMapGenerator::createMap($arrayOfSplFileInfoStreamPaths)
+		);
+	}
 
     public function testAmbiguousReference(): void
     {

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -212,16 +212,6 @@ class ClassMapGeneratorTest extends TestCase
 				return $this->resource === false ? false :
 					fstat($this->resource);
 			}
-
-			/**
-			 * @param string $path
-			 * @param int $flags
-			 *
-			 * @return array|false
-			 */
-			public function url_stat($path, $flags) {
-				return stat($this->real);
-			}
 		};
 
 		$testProxyStreamWrapper::$rootPath = realpath(__DIR__) . '/Fixtures/classmap';

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -206,7 +206,7 @@ class ClassMapGeneratorTest extends TestCase
 			}
 
 			/**
-			 * @return array|false
+			 * @return array<int|string, int>|false
 			 */
 			public function stream_stat() {
 				return $this->resource === false ? false :

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -149,89 +149,87 @@ class ClassMapGeneratorTest extends TestCase
         ), ClassMapGenerator::createMap($finder));
     }
 
-	/**
-	 * @see ClassMapGenerator::isStreamWrapper()
-	 */
-	public function testStreamWrapperSupport(): void {
+    /**
+     * @see ClassMapGenerator::isStreamWrapper()
+     */
+    public function testStreamWrapperSupport(): void {
 
-		/**
-		 * A stream wrapper that given `test://myfile.php` will read `test://path/to/myfile.php` where `path/to` is
-		 * set on the `$rootPath` static variable.
-		 */
-		$testProxyStreamWrapper = new class() {
-			/**
-			 * @var string
-			 */
-			public static $rootPath;
+        /**
+         * A stream wrapper that given `test://myfile.php` will read `test://path/to/myfile.php` where `path/to` is
+         * set on the `$rootPath` static variable.
+         */
+        $testProxyStreamWrapper = new class() {
+            /**
+             * @var string
+             */
+            public static $rootPath;
 
-			/**
-			 * @var string
-			 */
-			protected $real;
+            /**
+             * @var string
+             */
+            protected $real;
 
-			/**
-			 * @var resource|false
-			 */
-			protected $resource;
+            /**
+             * @var resource|false
+             */
+            protected $resource;
 
-			/**
-			 * @param string $path
-			 * @param string $mode
-			 * @param int $options
-			 * @param ?string $opened_path
-			 *
-			 * @return bool
-			 */
-			public function stream_open($path, $mode, $options, &$opened_path)
-			{
-				$scheme = parse_url($path, PHP_URL_SCHEME);
-				$varname = str_replace( $scheme . '://', '', $path );
+            /**
+             * @param string $path
+             * @param string $mode
+             * @param int $options
+             * @param ?string $opened_path
+             *
+             * @return bool
+             */
+            public function stream_open( $path, $mode, $options, &$opened_path ) {
+                $scheme  = parse_url( $path, PHP_URL_SCHEME );
+                $varname = str_replace( $scheme . '://', '', $path );
 
-				$this->real = 'file://' . self::$rootPath . '/' . $varname;
+                $this->real = 'file://' . self::$rootPath . '/' . $varname;
 
-				$this->resource = fopen($this->real, $mode);
+                $this->resource = fopen( $this->real, $mode );
 
-				return (bool) $this->resource;
-			}
+                return (bool) $this->resource;
+            }
 
-			/**
-			 * @param int<0, max>|null $count
-			 *
-			 * @return false|string
-			 */
-			public function stream_read($count)
-			{
-				return $this->resource === false ? false :
-					fgets($this->resource, $count);
-			}
+            /**
+             * @param int<0, max>|null $count
+             *
+             * @return false|string
+             */
+            public function stream_read( $count ) {
+                return $this->resource === false ? false :
+                    fgets( $this->resource, $count );
+            }
 
-			/**
-			 * @return array<int|string, int>|false
-			 */
-			public function stream_stat() {
-				return $this->resource === false ? false :
-					fstat($this->resource);
-			}
-		};
+            /**
+             * @return array<int|string, int>|false
+             */
+            public function stream_stat() {
+                return $this->resource === false ? false :
+                    fstat( $this->resource );
+            }
+        };
 
-		$testProxyStreamWrapper::$rootPath = realpath(__DIR__) . '/Fixtures/classmap';
-		stream_wrapper_register( 'test', get_class( $testProxyStreamWrapper ) );
+        $testProxyStreamWrapper::$rootPath = realpath( __DIR__ ) . '/Fixtures/classmap';
+        stream_wrapper_register( 'test', get_class( $testProxyStreamWrapper ) );
 
-		$arrayOfSplFileInfoStreamPaths = [
-			new \SplFileInfo( 'test://BackslashLineEndingString.php'),
-			new \SplFileInfo( 'test://InvalidUnicode.php'),
-		];
+        $arrayOfSplFileInfoStreamPaths = [
+            new \SplFileInfo( 'test://BackslashLineEndingString.php' ),
+            new \SplFileInfo( 'test://InvalidUnicode.php' ),
+        ];
 
-		self::assertSame(
-			[
-				'Foo\\SlashedA' => 'test://BackslashLineEndingString.php',
-				'Foo\\SlashedB' => 'test://BackslashLineEndingString.php',
-				'Smarty_Internal_Compile_Block' => 'test://InvalidUnicode.php',
-				'Smarty_Internal_Compile_Blockclose' => 'test://InvalidUnicode.php',
-			],
-			ClassMapGenerator::createMap($arrayOfSplFileInfoStreamPaths)
-		);
-	}
+        self::assertSame(
+            [
+                'Foo\\SlashedA'                      => 'test://BackslashLineEndingString.php',
+                'Foo\\SlashedB'                      => 'test://BackslashLineEndingString.php',
+                'Smarty_Internal_Compile_Block'      => 'test://InvalidUnicode.php',
+                'Smarty_Internal_Compile_Blockclose' => 'test://InvalidUnicode.php',
+            ],
+            ClassMapGenerator::createMap( $arrayOfSplFileInfoStreamPaths )
+        );
+    }
 
     public function testAmbiguousReference(): void
     {


### PR DESCRIPTION
I'm [trying to](https://github.com/BrianHenryIE/strauss/pull/139) add a `--dry-run` mode to [BrianHenryIE/strauss](https://github.com/BrianHenryIE/strauss). To achieve this I've written a FlySystem [ReadOnlyFilesytem class](https://github.com/BrianHenryIE/strauss/blob/add/dry-run/src/Helpers/ReadOnlyFileSystem.php) which uses a couple of in-memory filesystems to emulate the process without ever writing to the true filesystem. 

Obviously, I can't pass a Flysystem instance to third party libraries, such as this.

[elazar/flystream](https://github.com/elazar/flystream) to the rescue! Which allows registering `myscheme://` to then use your Flysystem of choice during normal `file_get_contents('myscheme://path/to/file.php')` operations.

Currently, `composer/class-map-generator` does some operations, e.g. `::isAbsolutePath()`, that mis-characterise `myscheme://...`.

This PR adds a `::isStreamWrapper()` function which is used in the `ClassMapGenerator::scanPaths()` function to enable using stream wrappers.

The test creates a stream wrapper that reads e.g. `test://BackslashLineEndingString.php` from `file://path/to/class-map-generator/tests/Fixtures/BackslashLineEndingString.php`.