### PR TITLE
Fix PSR-0 optimized classmap includes classes that do not match the configured namespace prefix 

### DIFF
--- a/src/ClassMapGenerator.php
+++ b/src/ClassMapGenerator.php
@@ -231,6 +231,11 @@ class ClassMapGenerator
         foreach ($classes as $class) {
             // transform class name to file path and validate
             if ('psr-0' === $namespaceType) {
+                if ('' !== $baseNamespace && !str_starts_with($class, $baseNamespace)) {
+                    $rejectedClasses[] = $class;
+                    continue;
+                }
+
                 $namespaceLength = strrpos($class, '\\');
                 if (false !== $namespaceLength) {
                     $namespace = substr($class, 0, $namespaceLength + 1);

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -437,6 +437,38 @@ class ClassMapGeneratorTest extends TestCase
         self::assertEquals($expected, $actual, $message);
     }
 
+    public function testPsr0OptimizedClassmapRespectsNamespacePrefix(): void
+    {
+        $this->generator->scanPaths(
+            __DIR__ . '/Fixtures/psr0NamespacePrefix',
+            null,
+            'psr-0',
+            'Acme_'
+        );
+
+        $classMap = $this->generator->getClassMap();
+        $map = $classMap->getMap();
+
+        self::assertArrayHasKey('Acme_Utils_Helper', $map);
+        self::assertArrayHasKey('Acme_Logger', $map);
+
+        self::assertArrayNotHasKey('Other\\Controller\\Page', $map);
+        self::assertArrayNotHasKey('Other\\Widget', $map);
+
+        self::assertArrayNotHasKey('Other_Service', $map);
+
+        $violations = $classMap->getPsrViolations();
+        sort($violations);
+        self::assertSame(
+            [
+                'Class Other\\Controller\\Page located in ./tests/Fixtures/psr0NamespacePrefix/Other/Controller/Page.php does not comply with psr-0 autoloading standard (rule: Acme_ => ./tests/Fixtures/psr0NamespacePrefix). Skipping.',
+                'Class Other\\Widget located in ./tests/Fixtures/psr0NamespacePrefix/Other/Widget.php does not comply with psr-0 autoloading standard (rule: Acme_ => ./tests/Fixtures/psr0NamespacePrefix). Skipping.',
+                'Class Other_Service located in ./tests/Fixtures/psr0NamespacePrefix/Other/Service.php does not comply with psr-0 autoloading standard (rule: Acme_ => ./tests/Fixtures/psr0NamespacePrefix). Skipping.',
+            ],
+            $violations
+        );
+    }
+
     public static function getUniqueTmpDirectory(): string
     {
         $attempts = 5;

--- a/tests/Fixtures/psr0NamespacePrefix/Acme/Logger.php
+++ b/tests/Fixtures/psr0NamespacePrefix/Acme/Logger.php
@@ -1,0 +1,5 @@
+<?php
+
+class Acme_Logger
+{
+}

--- a/tests/Fixtures/psr0NamespacePrefix/Acme/Utils/Helper.php
+++ b/tests/Fixtures/psr0NamespacePrefix/Acme/Utils/Helper.php
@@ -1,0 +1,5 @@
+<?php
+
+class Acme_Utils_Helper
+{
+}

--- a/tests/Fixtures/psr0NamespacePrefix/Other/Controller/Page.php
+++ b/tests/Fixtures/psr0NamespacePrefix/Other/Controller/Page.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Other\Controller;
+
+class Page
+{
+}

--- a/tests/Fixtures/psr0NamespacePrefix/Other/Service.php
+++ b/tests/Fixtures/psr0NamespacePrefix/Other/Service.php
@@ -1,0 +1,5 @@
+<?php
+
+class Other_Service
+{
+}

--- a/tests/Fixtures/psr0NamespacePrefix/Other/Widget.php
+++ b/tests/Fixtures/psr0NamespacePrefix/Other/Widget.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Other;
+
+class Widget
+{
+}


### PR DESCRIPTION
Fixes #32 

Restores the namespace prefix check for PSR-0 inside `filterByNamespace()`. This was removed in #8  to enable --strict-psr warnings for non-matching classes, but PSR-0 path computation uses the full class name without stripping the prefix, so the check was the only guard preventing false positive matches.
  
  
The fix adds the prefix check back inside the PSR-0 if branch only. Non-matching classes are still added to `$rejectedClasses` so PSR violation warnings are preserved.

PSR-4 is unaffected because it strips the prefix during path computation, so non-matching classes produce wrong paths and are rejected.



