### PR TITLE
Use strcspn instead of regex for fast-skip in clean()

### DIFF
--- a/src/PhpFileCleaner.php
+++ b/src/PhpFileCleaner.php
@@ -24,7 +24,7 @@ class PhpFileCleaner
     private static $typeConfig;
 
     /** @var non-empty-string */
-    private static $restPattern;
+    private static $rejectChars;
 
     /**
      * @readonly
@@ -60,7 +60,7 @@ class PhpFileCleaner
             ];
         }
 
-        self::$restPattern = '{[^?"\'</'.implode('', array_keys(self::$typeConfig)).']+}A';
+        self::$rejectChars = '?"\'</'.implode('', array_keys(self::$typeConfig));
     }
 
     public function __construct(string $contents, int $maxMatches)
@@ -128,9 +128,10 @@ class PhpFileCleaner
                 }
 
                 $this->index += 1;
-                if ($this->match(self::$restPattern, $match)) {
-                    $clean .= $char . $match[0];
-                    $this->index += \strlen($match[0]);
+                $skip = strcspn($this->contents, self::$rejectChars, $this->index);
+                if ($skip > 0) {
+                    $clean .= $char . \substr($this->contents, $this->index, $skip);
+                    $this->index += $skip;
                 } else {
                     $clean .= $char;
                 }


### PR DESCRIPTION
Hi,

I noticed on our project that `composer dump-autoload --classmap-authoritative` was suspicious slow. Looking into this showed `Composer\ClassMapGenerator\PhpFileCleaner` to be slow.

The regex used in `clean()` to skip up to certain character was the main culprit.

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/a9080317-ac4d-4fa8-ad12-f186ad3dd373" />
