### PR TITLE
[Draft RFC] Support named `extension` declarations (Extension Methods RFC, in review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Basic usage
 -----------
 
 If all you want is to scan a directory and extract a classmap with all
-classes/interfaces/traits/enums mapped to their paths, you can simply use:
+classes/interfaces/traits/enums (and named `extension` declarations from the
+proposed Extension Methods RFC) mapped to their paths, you can simply use:
 
 
 ```php

--- a/src/PhpFileCleaner.php
+++ b/src/PhpFileCleaner.php
@@ -20,7 +20,7 @@ use Composer\Pcre\Preg;
  */
 class PhpFileCleaner
 {
-    /** @var array<array{name: string, length: int, pattern: non-empty-string}> */
+    /** @var array<string, list<array{name: string, length: int, pattern: non-empty-string}>> */
     private static $typeConfig;
 
     /** @var non-empty-string */
@@ -52,11 +52,22 @@ class PhpFileCleaner
      */
     public static function setTypeConfig(array $types): void
     {
+        self::$typeConfig = [];
+
         foreach ($types as $type) {
-            self::$typeConfig[$type[0]] = [
+            if ('extension' === $type) {
+                // extension declarations are only recognized with the full "Name on Target $var" tail, both to
+                // rule out false positives ("extension" is a valid symbol name) and because the early-return
+                // in clean() must keep everything the parser regex needs to see
+                $pattern = '{.\b(?<![\$:>])extension\s++[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+\s++on\s++\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+\s*+\$[a-zA-Z_\x7f-\xff]}Ais';
+            } else {
+                $pattern = '{.\b(?<![\$:>])'.$type.'\s++[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+}Ais';
+            }
+
+            self::$typeConfig[$type[0]][] = [
                 'name' => $type,
                 'length' => \strlen($type),
-                'pattern' => '{.\b(?<![\$:>])'.$type.'\s++[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+}Ais',
+                'pattern' => $pattern,
             ];
         }
 
@@ -118,12 +129,13 @@ class PhpFileCleaner
                 }
 
                 if ($this->maxMatches === 1 && isset(self::$typeConfig[$char])) {
-                    $type = self::$typeConfig[$char];
-                    if (
-                        substr($this->contents, $this->index, $type['length']) === $type['name']
-                        && Preg::isMatch($type['pattern'], $this->contents, $match, 0, $this->index - 1)
-                    ) {
-                        return $clean . $match[0];
+                    foreach (self::$typeConfig[$char] as $type) {
+                        if (
+                            substr($this->contents, $this->index, $type['length']) === $type['name']
+                            && Preg::isMatch($type['pattern'], $this->contents, $match, 0, $this->index - 1)
+                        ) {
+                            return $clean . $match[0];
+                        }
                     }
                 }
 

--- a/src/PhpFileParser.php
+++ b/src/PhpFileParser.php
@@ -59,7 +59,7 @@ class PhpFileParser
         }
 
         // return early if there is no chance of matching anything in this file
-        Preg::matchAllStrictGroups('{\b(?:class|interface|trait'.$extraTypes.')\s}i', $contents, $matches);
+        Preg::matchAllStrictGroups('{\b(?:class|interface|trait|extension'.$extraTypes.')\s}i', $contents, $matches);
         if ([] === $matches[0]) {
             return [];
         }
@@ -71,6 +71,7 @@ class PhpFileParser
         Preg::matchAll('{
             (?:
                  \b(?<![\\\\$:>])(?P<type>class|interface|trait'.$extraTypes.') \s++ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+)
+               | \b(?<![\\\\$:>])(?P<ext>extension) \s++ (?P<extname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+) \s++ on \s++ \\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+ \s*+ \$[a-zA-Z_\x7f-\xff]
                | \b(?<![\\\\$:>])(?P<ns>namespace) (?P<nsname>\s++[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+)? \s*+ [\{;]
             )
         }ix', $contents, $matches);
@@ -81,6 +82,16 @@ class PhpFileParser
         for ($i = 0, $len = \count($matches['type']); $i < $len; ++$i) {
             if (isset($matches['ns'][$i]) && $matches['ns'][$i] !== '') {
                 $namespace = str_replace([' ', "\t", "\r", "\n"], '', (string) $matches['nsname'][$i]) . '\\';
+            } elseif (isset($matches['ext'][$i]) && $matches['ext'][$i] !== '') {
+                // named extension declarations (proposed "Extension Methods" RFC) declare the identifier
+                // before "on"; the target type after "on" and the receiver variable are not part of the name,
+                // and the anonymous form ("extension Target $var {") declares no autoloadable symbol at all
+                $name = $matches['extname'][$i];
+                \assert(\is_string($name));
+
+                /** @var class-string */
+                $className = ltrim($namespace . $name, '\\');
+                $classes[] = $className;
             } else {
                 $name = $matches['name'][$i];
                 \assert(\is_string($name));
@@ -131,7 +142,7 @@ class PhpFileParser
                 $extraTypesArray = ['enum'];
             }
 
-            PhpFileCleaner::setTypeConfig(array_merge(['class', 'interface', 'trait'], $extraTypesArray));
+            PhpFileCleaner::setTypeConfig(array_merge(['class', 'interface', 'trait', 'extension'], $extraTypesArray));
         }
 
         return $extraTypes;

--- a/src/PhpFileParser.php
+++ b/src/PhpFileParser.php
@@ -21,6 +21,20 @@ use Composer\Pcre\Preg;
 class PhpFileParser
 {
     /**
+     * Regex fragment matching a named extension declaration (proposed "Extension Methods" RFC)
+     *
+     * Captures the declared name (extname) and the raw target token after "on" (exttarget). The
+     * target is captured exactly as written in the source — possibly a relative name or an alias
+     * from a "use" import, unresolved — in anticipation of the target-hint optimization described
+     * in the RFC's Future Scope. It is not used yet and is not part of the class map output.
+     *
+     * Must remain embeddable in a case-insensitive, whitespace-extended ("ix") pattern.
+     *
+     * @internal
+     */
+    public const EXTENSION_REGEX = '\b(?<![\\\\$:>])(?P<ext>extension) \s++ (?P<extname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+) \s++ on \s++ (?P<exttarget>\\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+) \s*+ \$[a-zA-Z_\x7f-\xff]';
+
+    /**
      * Extract the classes in the given file
      *
      * @param  string            $path The file to check
@@ -71,7 +85,7 @@ class PhpFileParser
         Preg::matchAll('{
             (?:
                  \b(?<![\\\\$:>])(?P<type>class|interface|trait'.$extraTypes.') \s++ (?P<name>[a-zA-Z_\x7f-\xff:][a-zA-Z0-9_\x7f-\xff:\-]*+)
-               | \b(?<![\\\\$:>])(?P<ext>extension) \s++ (?P<extname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+) \s++ on \s++ \\\\?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+ \s*+ \$[a-zA-Z_\x7f-\xff]
+               | '.self::EXTENSION_REGEX.'
                | \b(?<![\\\\$:>])(?P<ns>namespace) (?P<nsname>\s++[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+(?:\s*+\\\\\s*+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+)*+)? \s*+ [\{;]
             )
         }ix', $contents, $matches);

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -117,6 +117,19 @@ class ClassMapGeneratorTest extends TestCase
             'Dummy\Test\AnonClassHolder' => __DIR__ . '/Fixtures/php7.0/anonclass.php',
         ]];
 
+        // proposed "Extension Methods" RFC, recognized on any PHP version as parsing is purely text-based
+        $data[] = [__DIR__ . '/Fixtures/extensions', [
+            'DomTraversal' => __DIR__ . '/Fixtures/extensions/ExtensionGlobal.php',
+            'Acme\DomKit\DomTraversal' => __DIR__ . '/Fixtures/extensions/ExtensionNamespaced.php',
+            'Acme\Scalars\StringHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionScalarTargets.php',
+            'Acme\Scalars\ArrayHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionScalarTargets.php',
+            'Acme\Multiline\WidgetHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionMultiline.php',
+            'Acme\Multiline\CaseInsensitive' => __DIR__ . '/Fixtures/extensions/ExtensionMultiline.php',
+            'Acme\Tricky\extension' => __DIR__ . '/Fixtures/extensions/ExtensionFalsePositives.php',
+            'Acme\Mixed\Formatter' => __DIR__ . '/Fixtures/extensions/ExtensionWithClass.php',
+            'Acme\Mixed\FormatterHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionWithClass.php',
+        ]];
+
         if (PHP_VERSION_ID >= 80100) {
             $data[] = [__DIR__ . '/Fixtures/php8.1', [
                 'RolesBasicEnum' => __DIR__ . '/Fixtures/php8.1/enum_basic.php',
@@ -412,6 +425,45 @@ class ClassMapGeneratorTest extends TestCase
         self::assertCount(1, $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath]);
         self::assertSame('Class UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope located in ./tests/Fixtures/psrViolations/ClassWithNameSpaceOutsideConfiguredScope.php does not comply with psr-4 autoloading standard (rule: ExpectedNamespace\ => ./tests/Fixtures/psrViolations). Skipping.', $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath][0]['warning']);
         self::assertSame('UnexpectedNamespace\ClassWithNameSpaceOutsideConfiguredScope', $rawViolations[$classWithNameSpaceOutsideConfiguredScopeFilepath][0]['className']);
+    }
+
+    public function testExtensionDeclarationsFollowPsr4Rules(): void
+    {
+        $this->generator->scanPaths(__DIR__ . '/Fixtures/psr4Extensions', null, 'psr-4', 'ExpectedNamespace\\');
+        $classMap = $this->generator->getClassMap();
+
+        // a named extension declaration matching the file path is accepted as the file's expected symbol
+        self::assertArrayHasKey('ExpectedNamespace\\DomTraversal', $classMap->getMap());
+
+        self::assertSame(
+            [
+                'Class ExpectedNamespace\SomeOtherName located in ./tests/Fixtures/psr4Extensions/ExtensionWithIncorrectName.php does not comply with psr-4 autoloading standard (rule: ExpectedNamespace\ => ./tests/Fixtures/psr4Extensions). Skipping.',
+            ],
+            $classMap->getPsrViolations()
+        );
+    }
+
+    /**
+     * Extension names live in the same name=>file map as class-like symbols, so
+     * duplicates produce the usual ambiguous class warnings
+     */
+    public function testExtensionNamesShareNamespaceWithClasses(): void
+    {
+        $tempDir = self::getUniqueTmpDirectory();
+        mkdir($tempDir.'/other');
+
+        file_put_contents($tempDir . '/A.php', "<?php\nclass A {}");
+        file_put_contents($tempDir . '/other/A.php', "<?php\nextension A on \\ArrayObject \$a {}");
+
+        $this->generator->scanPaths($tempDir);
+        $classMap = $this->generator->getClassMap();
+
+        self::assertCount(1, $classMap->getAmbiguousClasses());
+        self::assertArrayHasKey('A', $classMap->getAmbiguousClasses());
+        self::assertCount(1, $classMap->getAmbiguousClasses()['A']);
+
+        $fs = new Filesystem();
+        $fs->remove($tempDir);
     }
 
     public function testCreateMapWithDirectoryExcluded(): void

--- a/tests/ClassMapGeneratorTest.php
+++ b/tests/ClassMapGeneratorTest.php
@@ -123,6 +123,7 @@ class ClassMapGeneratorTest extends TestCase
             'Acme\DomKit\DomTraversal' => __DIR__ . '/Fixtures/extensions/ExtensionNamespaced.php',
             'Acme\Scalars\StringHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionScalarTargets.php',
             'Acme\Scalars\ArrayHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionScalarTargets.php',
+            'Acme\Aliased\WidgetShortcuts' => __DIR__ . '/Fixtures/extensions/ExtensionAliasedTarget.php',
             'Acme\Multiline\WidgetHelpers' => __DIR__ . '/Fixtures/extensions/ExtensionMultiline.php',
             'Acme\Multiline\CaseInsensitive' => __DIR__ . '/Fixtures/extensions/ExtensionMultiline.php',
             'Acme\Tricky\extension' => __DIR__ . '/Fixtures/extensions/ExtensionFalsePositives.php',

--- a/tests/Fixtures/extensions/ExtensionAliasedTarget.php
+++ b/tests/Fixtures/extensions/ExtensionAliasedTarget.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Acme\Aliased;
+
+use Acme\Widgets\Widget as W;
+
+extension WidgetShortcuts on W $w
+{
+}

--- a/tests/Fixtures/extensions/ExtensionAnonymous.php
+++ b/tests/Fixtures/extensions/ExtensionAnonymous.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Acme\Anon;
+
+// anonymous extensions have no name and are not autoloadable, they must not end up in the class map
+
+extension \DateTimeImmutable $date
+{
+    public function tomorrow(): \DateTimeImmutable
+    {
+        return $date->modify('+1 day');
+    }
+}
+
+extension string $s
+{
+    public function shout(): string
+    {
+        return \strtoupper($s);
+    }
+}

--- a/tests/Fixtures/extensions/ExtensionFalsePositives.php
+++ b/tests/Fixtures/extensions/ExtensionFalsePositives.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Acme\Tricky;
+
+// "extension" is a valid symbol name in PHP today, and the RFC's import
+// statement ("use extension ...") declares nothing; none of the usages below
+// may produce a class map entry except the class actually named "extension"
+
+use extension Acme\DomKit\DomTraversal;
+
+class extension extends \ArrayObject
+{
+    public function extension(string $x): string
+    {
+        return \pathinfo($x, \PATHINFO_EXTENSION);
+    }
+}
+
+function extension(string $s): string
+{
+    $obj = new extension();
+    $obj->extension($s);
+
+    return 'extension Foo on Bar $b { }';
+}

--- a/tests/Fixtures/extensions/ExtensionGlobal.php
+++ b/tests/Fixtures/extensions/ExtensionGlobal.php
@@ -1,0 +1,9 @@
+<?php
+
+extension DomTraversal on \DOMElement $el
+{
+    public function firstByClass(string $class): ?\DOMElement
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/extensions/ExtensionMultiline.php
+++ b/tests/Fixtures/extensions/ExtensionMultiline.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Acme\Multiline;
+
+extension
+    // the declaration may be spread over several lines
+    WidgetHelpers
+    /* with comments between any two tokens */
+    on
+    \Acme\Widgets\Widget
+    $widget
+{
+}
+
+EXTENSION CaseInsensitive ON Widgets\Widget $w
+{
+}

--- a/tests/Fixtures/extensions/ExtensionNamespaced.php
+++ b/tests/Fixtures/extensions/ExtensionNamespaced.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme\DomKit;
+
+extension DomTraversal on \DOMElement $el
+{
+    public function firstByClass(string $class): ?\DOMElement
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/extensions/ExtensionScalarTargets.php
+++ b/tests/Fixtures/extensions/ExtensionScalarTargets.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Acme\Scalars;
+
+extension StringHelpers on string $s
+{
+    public function isBlank(): bool
+    {
+        return \trim($s) === '';
+    }
+}
+
+extension ArrayHelpers on array $items
+{
+    public function isEmpty(): bool
+    {
+        return $items === [];
+    }
+}

--- a/tests/Fixtures/extensions/ExtensionWithClass.php
+++ b/tests/Fixtures/extensions/ExtensionWithClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme\Mixed;
+
+class Formatter
+{
+}
+
+extension FormatterHelpers on Formatter $formatter
+{
+}

--- a/tests/Fixtures/psr4Extensions/DomTraversal.php
+++ b/tests/Fixtures/psr4Extensions/DomTraversal.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ExpectedNamespace;
+
+extension DomTraversal on \DOMElement $el
+{
+    public function firstByClass(string $class): ?\DOMElement
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/psr4Extensions/ExtensionWithIncorrectName.php
+++ b/tests/Fixtures/psr4Extensions/ExtensionWithIncorrectName.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ExpectedNamespace;
+
+extension SomeOtherName on string $s
+{
+}

--- a/tests/PhpFileParserTest.php
+++ b/tests/PhpFileParserTest.php
@@ -18,6 +18,7 @@
 
 namespace Composer\ClassMapGenerator;
 
+use Composer\Pcre\Preg;
 use PHPUnit\Framework\TestCase;
 
 class PhpFileParserTest extends TestCase
@@ -27,5 +28,63 @@ class PhpFileParserTest extends TestCase
         self::expectException('RuntimeException');
         self::expectExceptionMessage('does not exist');
         PhpFileParser::findClasses(__DIR__ . '/no-file');
+    }
+
+    /**
+     * The raw target token after "on" is captured as written (relative names and import
+     * aliases stay unresolved), in anticipation of the target-hint optimization from the
+     * Extension Methods RFC's Future Scope. It is not part of the class map output.
+     *
+     * @dataProvider extensionTargetProvider
+     * @param array<string, string> $expected extension name => raw target token
+     */
+    public function testExtensionTargetIsCapturedRaw(string $file, array $expected): void
+    {
+        PhpFileCleaner::setTypeConfig(['class', 'interface', 'trait', 'extension', 'enum']);
+
+        $contents = php_strip_whitespace($file);
+        // maxMatches > 1 disables the cleaner's single-match early return so the whole file is cleaned
+        $cleaner = new PhpFileCleaner($contents, PHP_INT_MAX);
+        $contents = $cleaner->clean();
+
+        Preg::matchAllStrictGroups('{'.PhpFileParser::EXTENSION_REGEX.'}ix', $contents, $matches);
+
+        $actual = [];
+        foreach ($matches['extname'] as $i => $name) {
+            $actual[$name] = $matches['exttarget'][$i];
+        }
+
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * @return array<string, array{string, array<string, string>}>
+     */
+    public static function extensionTargetProvider(): array
+    {
+        return [
+            'fully-qualified target' => [__DIR__ . '/Fixtures/extensions/ExtensionGlobal.php', [
+                'DomTraversal' => '\DOMElement',
+            ]],
+            'fully-qualified target in namespace' => [__DIR__ . '/Fixtures/extensions/ExtensionNamespaced.php', [
+                'DomTraversal' => '\DOMElement',
+            ]],
+            'scalar and array targets' => [__DIR__ . '/Fixtures/extensions/ExtensionScalarTargets.php', [
+                'StringHelpers' => 'string',
+                'ArrayHelpers' => 'array',
+            ]],
+            'relative qualified target stays unresolved' => [__DIR__ . '/Fixtures/extensions/ExtensionMultiline.php', [
+                'WidgetHelpers' => '\Acme\Widgets\Widget',
+                'CaseInsensitive' => 'Widgets\Widget',
+            ]],
+            'aliased target stays unresolved' => [__DIR__ . '/Fixtures/extensions/ExtensionAliasedTarget.php', [
+                'WidgetShortcuts' => 'W',
+            ]],
+            'unqualified target' => [__DIR__ . '/Fixtures/extensions/ExtensionWithClass.php', [
+                'FormatterHelpers' => 'Formatter',
+            ]],
+            'anonymous forms capture nothing' => [__DIR__ . '/Fixtures/extensions/ExtensionAnonymous.php', []],
+            'false positives capture nothing' => [__DIR__ . '/Fixtures/extensions/ExtensionFalsePositives.php', []],
+        ];
     }
 }


### PR DESCRIPTION
## What

Draft support for the **named form** of `extension` declarations from the proposed PHP "Extension Methods" RFC family, which is currently in informal review:

- [Base RFC draft](https://gist.github.com/hollyschilling/f590f3a1e488732eea5b0d8014702276)
- [Scalars RFC draft](https://gist.github.com/hollyschilling/1d247189b8bf45fe044bfbe7fb07dcdb)
- [Visibility RFC draft](https://gist.github.com/hollyschilling/dc97ea217302de2f4c9ad7d527aaa65b) (defines the named form)

The named form declares an autoloadable symbol, namespaced exactly like a `class` declaration's name:

```php
namespace Acme\DomKit;

extension DomTraversal on \DOMElement $el
{
    public function firstByClass(string $class): ?\DOMElement { /* ... */ }
}
```

→ class-map entry `Acme\DomKit\DomTraversal` mapping to this file. The target after `on` and the receiver variable are not part of the name and are not captured.

This follows the approach used when `enum` support was added (composer/composer#9670): parsing is purely text-based (`PhpFileCleaner` + regex), so it does not depend on `token_get_all()` or on the running PHP understanding the syntax, and works on every PHP version this package supports.

## How

- **`PhpFileParser`**: `extension` is added to the early-exit prefilter, and the main regex gets a dedicated branch that requires the full `extension Name on Target $var` tail. `extension` and `on` are contextual identifiers in the RFC grammar, so requiring the complete tail (including the mandatory receiver variable) is what makes false positives near-impossible — `extension` remains a perfectly valid class/function/method name today. The target may be an identifier, qualified/fully-qualified name, or a built-in type name (`string`, `int`, `float`, `bool`, `array`). Keywords match case-insensitively like the existing ones.
- **`PhpFileCleaner`**: the keyword shortlist was keyed by first character, so `extension` collided with `enum` under `e`; the config now holds a list per character. `extension` gets a tail-aware pattern so the single-match early return keeps everything the parser regex needs to see (a name-only pattern would truncate the declaration after the name and drop the match).
- The **anonymous form** (`extension \DateTimeImmutable $date { ... }`, `extension string $s { ... }`) declares no addressable symbol and produces no entry — it can't match because there is no `Name on` sequence.
- The RFC's **`use extension Acme\DomKit\Traversal;` import statement** declares nothing and produces no entry — it can't match because no `on Target $var` tail follows.
- **PSR-4 / PSR-0 validation** needed no changes: `filterByNamespace()` is symbol-agnostic, so a named extension declaration matching the file path is accepted as the file's expected symbol (covered by tests). PSR-4 itself needs no amendment either — the spec's "classes, interfaces, traits, and other similar structures" wording covers extension declarations, as it did enums.
- **Duplicate names**: extension names live in the same name→file map as class-like symbols and reuse the existing ambiguous-class warning behavior (covered by tests). Note that name-collision policy between extensions and class-like symbols is still an open question in the RFC; if the RFC lands on a separate symbol space, this can be revisited.
- **Target capture (future-proofing only)**: the regex captures the raw target token after `on` as a named group (`exttarget`), exactly as written in the source — relative names and import aliases stay unresolved (covered by tests, including an aliased-target fixture). Nothing consumes it yet and the class map output is unchanged; this settles the pattern shape for the target-hint optimization described in the RFC's Future Scope (the engine filters autoload candidates by target, with a load-the-rest fallback). The extension branch of the parser regex is exposed as an `@internal` constant so the tests assert against the exact pattern used in production.

## Deliberately not in this PR

No new autoload artifact and no map format change (no `autoload_extensions.php`, no target metadata in the emitted map). That half waits until the engine-side hint API is a live proposal — keeping this PR minimal and mergeable on the enum precedent.

## Tests

New fixtures cover: global + namespaced named forms, fully-qualified/qualified/unqualified/scalar/`array` targets, a multiline declaration with comments between tokens, non-lowercase keywords, both anonymous forms (no entries), an extension declared alongside a class in one file (both mapped), PSR-4 acceptance + PSR-4 violation for a mis-named extension, duplicate-name ambiguity, and the false-positive zoo: `class extension`, `function extension()`, `$obj->extension()`, `new extension()`, `use extension …;`, and a declaration inside a string literal.

Fixture files use the proposed syntax and are not valid PHP on any current version; they sit under `tests/Fixtures/`, which lint, php-cs-fixer, and PHPStan already exclude (same mechanism as the enum fixtures on PHP < 8.1).

## Why now / draft status

Map entries for extension names are inert until PHP ships the engine-side autoload trigger (a later phase of the RFC), so landing this early is harmless and unblocks the ecosystem story. The grammar is draft-stable but not final — this PR tracks the RFC and should stay **draft** until the RFC is accepted.

Disclosure: I am the author of the RFC drafts linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
